### PR TITLE
Insert User Into DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/project03/spring/Application.java
+++ b/src/main/java/com/project03/spring/Application.java
@@ -2,6 +2,7 @@
 package com.project03.spring;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -25,10 +26,30 @@ public class Application {
 
 	@GetMapping("/users")
 	public String select(@RequestParam(value = "username", defaultValue = "Test") String username) {
-		String sql = "SELECT username FROM users WHERE username='" + username + "'";
-		String rows = template.queryForObject(sql, String.class);
+		String sql = "SELECT username FROM users WHERE username = ?";
+		String rows = template.queryForObject(sql, String.class, new Object[] { username });
 		System.out.println(rows);
 		return String.format("User %s exists", rows);
+	}
+
+	@PostMapping("/users")
+	public String register(@RequestParam(value="username") String username, @RequestParam(value="password") String password) {
+		String sql = "SELECT username FROM users WHERE username ='" + username + "'";
+		String rows;
+		try {
+			rows = template.queryForObject(sql, String.class);
+		}
+		catch (EmptyResultDataAccessException e) {
+			rows = "";
+		}
+
+
+		if (rows.length() == 0) {
+			sql = "INSERT INTO users (username, password) VALUES (?, ?)";
+			template.update(sql, username, password);
+			return "User " + username + " created successfully!";
+		}
+		return "User " + username + " already exists!";
 	}
 	
 	@DeleteMapping("/users")

--- a/src/test/java/com/project03/spring/UserTests.java
+++ b/src/test/java/com/project03/spring/UserTests.java
@@ -1,0 +1,41 @@
+package com.project03.spring;
+import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.test.web.servlet.MockMvcBuilderSupport;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+// @WebMvcTest(Application.class)
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserTests {
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+	void createUser() throws Exception {
+        mockMvc.perform(post("/users?username=BEST&password=YEST"));
+	}
+}


### PR DESCRIPTION
## Changes:
This PR adds the API necessary for #11
- Called by making a POST call to /users with username and password parameters
  - i.e [url]/users?username={username}&password={password}
- Checks for existing username in the DB before inserting

## Other Notes:
Currently the route only returns a string stating if the registration was successful or if the username already exists. I imagine that might need to be changed in the future depending on how android handles responses. 